### PR TITLE
Limit SimpleCov Use

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,8 @@ branches:
   only:
     - master
     - development
+
+# environment variables
+env:
+  global:
+    - CI=true

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,8 @@
 # Start coverage analysis
-require 'simplecov'
-SimpleCov.start 'rails'
+if ENV['CI'] == 'true' || ENV['COVERAGE'] == 'true'
+  require 'simplecov'
+  SimpleCov.start 'rails'
+end
 
 # Report coverage to codecov during CI
 if ENV['CI'] == 'true'


### PR DESCRIPTION
Only start/run SimpleCov when environment variable 'CI' or 'COVERAGE' is set to true. For Travis, we set 'CI' to true.